### PR TITLE
printstrings doesn't produce n unique hypothesis

### DIFF
--- a/cpp/fsttools/printstrings.main.cpp
+++ b/cpp/fsttools/printstrings.main.cpp
@@ -349,7 +349,12 @@ int run ( ucam::util::RegistryPO const& rg) {
       continue;
     }
 
-
+    // Otherwise determinization runs (both determinizefst or
+    // inside shortestpath) doesn't produce the expected result.
+    if (unique) {
+      fst::RmEpsilon<Arc>(&*ifst);
+      //      *ifst=fst::DeterminizeFst<Arc>(*ifst);
+    }
     // find nbest, compute stats, print
     ShortestPath (*ifst, &nfst, n, unique );
 


### PR DESCRIPTION
If lattices contain epsilons, we have more hypotheses
RmEpsilon needs to be applied first to the lattice.